### PR TITLE
Multi-target to .NET Standard 2.1, .NET 5 and .NET 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet: ['3.1.x']
+        dotnet: ['3.1.x', '5.0.x', '6.0.x']
     # services:
       # localstack:
       #   image: localstack/localstack:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet: ['3.1.x', '5.0.x', '6.0.x']
     # services:
       # localstack:
       #   image: localstack/localstack:latest
@@ -23,11 +20,24 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET
+
+    - name: Install .NET Core 3.1.x
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: ${{ matrix.dotnet }}
+        dotnet-version: 3.1.x
+
+    - name: Install .NET Core 5.0.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+    
+    - name: Install .NET Core 6.0.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+
     - name: Build
       run: dotnet build 
+      
     - name: Test
       run: dotnet test --no-build

--- a/src/Baseline.Labourer.DependencyInjection/Baseline.Labourer.DependencyInjection.csproj
+++ b/src/Baseline.Labourer.DependencyInjection/Baseline.Labourer.DependencyInjection.csproj
@@ -5,9 +5,19 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.22" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.22" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net5'">
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6'">
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Baseline.Labourer.Queue.Memory/Baseline.Labourer.Queue.Memory.csproj
+++ b/src/Baseline.Labourer.Queue.Memory/Baseline.Labourer.Queue.Memory.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>netstandard2.1;net5;net6</TargetFrameworks>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/src/Baseline.Labourer.Queue.NoOp/Baseline.Labourer.Queue.NoOp.csproj
+++ b/src/Baseline.Labourer.Queue.NoOp/Baseline.Labourer.Queue.NoOp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>netstandard2.1;net5;net6</TargetFrameworks>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/src/Baseline.Labourer.Server/Baseline.Labourer.Server.csproj
+++ b/src/Baseline.Labourer.Server/Baseline.Labourer.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFrameworks>netstandard2.1;net5;net6</TargetFrameworks>
 		<Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/src/Baseline.Labourer.Store.Memory/Baseline.Labourer.Store.Memory.csproj
+++ b/src/Baseline.Labourer.Store.Memory/Baseline.Labourer.Store.Memory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFrameworks>netstandard2.1;net5;net6</TargetFrameworks>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/src/Baseline.Labourer.Store.NoOp/Baseline.Labourer.Store.NoOp.csproj
+++ b/src/Baseline.Labourer.Store.NoOp/Baseline.Labourer.Store.NoOp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>netstandard2.1;net5;net6</TargetFrameworks>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/src/Baseline.Labourer/Baseline.Labourer.csproj
+++ b/src/Baseline.Labourer/Baseline.Labourer.csproj
@@ -1,14 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>netstandard2.1</TargetFramework>
+	  <TargetFrameworks>netstandard2.1;net5;net6</TargetFrameworks>
       <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.22" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5'">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="ncrontab" Version="3.3.1" />
     <PackageReference Include="System.Text.Json" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ncrontab" Version="3.3.1" />
   </ItemGroup>
 
 </Project>

--- a/test/Baseline.Labourer.DependencyInjection.Tests/Baseline.Labourer.DependencyInjection.Tests.csproj
+++ b/test/Baseline.Labourer.DependencyInjection.Tests/Baseline.Labourer.DependencyInjection.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5;net6</TargetFrameworks>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/test/Baseline.Labourer.Queue.Memory.Tests/Baseline.Labourer.Queue.Memory.Tests.csproj
+++ b/test/Baseline.Labourer.Queue.Memory.Tests/Baseline.Labourer.Queue.Memory.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5;net6</TargetFrameworks>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/test/Baseline.Labourer.Server.Tests/Baseline.Labourer.Server.Tests.csproj
+++ b/test/Baseline.Labourer.Server.Tests/Baseline.Labourer.Server.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<TargetFrameworks>netcoreapp3.1;net5;net6</TargetFrameworks>
 		<IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/test/Baseline.Labourer.Store.Memory.Tests/Baseline.Labourer.Store.Memory.Tests.csproj
+++ b/test/Baseline.Labourer.Store.Memory.Tests/Baseline.Labourer.Store.Memory.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5;net6</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Baseline.Labourer.Tests/Baseline.Labourer.Tests.csproj
+++ b/test/Baseline.Labourer.Tests/Baseline.Labourer.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>netcoreapp3.1</TargetFramework>
+	  <TargetFrameworks>netcoreapp3.1;net5;net6</TargetFrameworks>
       <IsPackable>false</IsPackable>
       <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Adds targets for .NET Standard 2.1, .NET 5 and .NET 6 in order to specify better dependency versions. Previously, any users of the library would be forced to use the 6.0.0 version of all Microsoft libraries which might break compatibility with others. By using the dependency version suited to the .NET version (i.e. 3.1.22 for .NET Standard 2.1, 5.0.0 for .NET 5 and so on) this will allow the library to be as compatible with the wider ecosystem as possible.